### PR TITLE
Allow Symfony console 3.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "require": {
         "php": "^7.1",
         "symfony/thanks": "^1.0",
-        "symfony/console": "^3.0|^4.0",
+        "symfony/console": "^3.4|^4.0",
         "monolog/monolog": "^1.23",
         "rokka/client": "^1.3",
         "liip/imagine-bundle": "^2.1"

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "require": {
         "php": "^7.1",
         "symfony/thanks": "^1.0",
-        "symfony/console": "^4.0",
+        "symfony/console": "^3.0|^4.0",
         "monolog/monolog": "^1.23",
         "rokka/client": "^1.3",
         "liip/imagine-bundle": "^2.1"


### PR DESCRIPTION
Using ez platform 2, we're on Symfony 3.4. This would allow to install the bundle with verision 3.4