### PR TITLE
RokkaResolver does not expect a string in constructor

### DIFF
--- a/Resources/config/services.yaml
+++ b/Resources/config/services.yaml
@@ -49,7 +49,6 @@ services:
         arguments:
             - "@liip_rokka_imagine.factory.rokka.client.template_helper_factory"
             - "@liip_rokka_imagine.config.rokka_credentials"
-            - "%liip_rokka_imagine.images_dir%"
         tags:
             - { name: "liip_imagine.cache.resolver", resolver: rokka }
 


### PR DESCRIPTION
This fixes the exception in the container: `Type error: Argument 3 passed to Liip\RokkaImagineBundle\Imagine\Cache\Resolver\RokkaResolver::__construct() must be an instance of Liip\RokkaImagineBundle\Config\BundleConfig, string given`