### PR TITLE
fix travis badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # LiipRokkaImagineBundle
 
-![Travis](https://travis-ci.org/liip/LiipRokkaImagineBundle.svg?branch=master)
+[![Travis Build](https://travis-ci.com/liip/LiipRokkaImagineBundle.svg?branch=master)](https://travis-ci.com/liip/LiipRokkaImagineBundle)
 
 ## Overview
 


### PR DESCRIPTION
i don't know why this is built on travis-ci.com rather than travis-ci.org but its how it is.

and with the changes, we link to the travis overview page.