### PR TITLE
Allow monolog/monolog ^2.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "require": {
         "php": "^7.1",
         "symfony/console": "^3.4 || ^4.3 || ^5.0",
-        "monolog/monolog": "^1.23",
+        "monolog/monolog": "^1.23 || ^2.1",
         "rokka/client": "^1.3",
         "liip/imagine-bundle": "^2.1"
     },


### PR DESCRIPTION
The monolog calls are compatible with the last monolog version, so let composer install it if it is needed